### PR TITLE
Add Travis CI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+
+python:
+  - "2.7"
+
+branches:
+  only:
+    - master
+
+install:
+  - pip install tox
+
+script:
+  - tox
+
+env:
+  - TOXENV=py27
+  - TOXENV=py34
+  - TOXENV=doc
+  - TOXENV=sphinx
+


### PR DESCRIPTION
The .travis.yml configures Travis CI. We only need Python 2.7 as the
rest is handled by different tox environments. In order to enable
Travis CI, please read http://docs.travis-ci.com/user/getting-started/ and
do step 1) and step 2).

Signed-off-by: Christian Heimes <cheimes@redhat.com>